### PR TITLE
윤필도 / 7월4주차 / 2문제

### DIFF
--- a/happypildo/[BOJ]_hanoi_1914.py
+++ b/happypildo/[BOJ]_hanoi_1914.py
@@ -1,0 +1,19 @@
+def hanoi(N, start_poll, end_poll, middle_poll):
+    result = ""
+
+    if N == 1:
+        return f"{start_poll} {end_poll}\n"
+
+    result = result + hanoi(N-1, start_poll=start_poll, end_poll=middle_poll, middle_poll=end_poll)
+    result = result + f"{start_poll} {end_poll}\n"
+    result = result + hanoi(N-1, start_poll=middle_poll, end_poll=end_poll, middle_poll=start_poll)
+
+    return result
+
+N = int(input())
+
+if N > 20:
+    print(2 ** N - 1)
+else:
+    print(2 ** N - 1)
+    print(hanoi(N=N, start_poll=1, end_poll=3, middle_poll=2))

--- a/happypildo/[BOJ]_hanoi_1914.py
+++ b/happypildo/[BOJ]_hanoi_1914.py
@@ -10,6 +10,7 @@ def hanoi(N, start_poll, end_poll, middle_poll):
 
     return result
 
+
 N = int(input())
 
 if N > 20:

--- a/happypildo/[SEA]_1W_HW.py
+++ b/happypildo/[SEA]_1W_HW.py
@@ -1,0 +1,65 @@
+OPERATORS = ['+', '-', '*', '/']
+OPERATOR_ORDERS = []
+memoization = {}
+
+
+def recursively_make_operator_order(selected, remain):
+    global OPERATOR_ORDERS
+    global memoization
+
+    if memoization.get(selected, 0) == remain:
+        return
+    if remain == "":
+        OPERATOR_ORDERS.append(selected)
+    for idx in range(len(remain)):
+        memoization[selected] = remain
+        recursively_make_operator_order(selected + remain[idx], remain[:idx] + remain[idx + 1:])
+
+
+def get_possible_calculation(num_set):
+    global OPERATOR_ORDERS
+    possible_calculation = []
+
+    for operator_order in OPERATOR_ORDERS:
+        temp_num_set = num_set[:]
+        result = 0
+
+        for offset in range(0, len(num_set) - 1):
+            left_hand = temp_num_set[offset]
+            right_hand = temp_num_set[offset + 1]
+            operator = operator_order[offset]
+
+            if operator == '+':
+                result = left_hand + right_hand
+            elif operator == '-':
+                result = left_hand - right_hand
+            elif operator == '*':
+                result = left_hand * right_hand
+            elif operator == '/':
+                result = int(left_hand / right_hand)
+
+            temp_num_set[offset + 1] = result
+
+        possible_calculation.append(result)
+
+    return possible_calculation
+
+
+T = int(input())
+for t_iter in range(1, T + 1):
+    N = int(input())
+    operator_count_set = [n for n in list(map(int, input().split()))]
+    num_set = [n for n in list(map(int, input().split()))]
+
+    operator_set = ""
+    for idx, count in enumerate(operator_count_set):
+        for _ in range(count):
+            operator_set = operator_set + OPERATORS[idx]
+
+    # Initialization
+    OPERATOR_ORDERS = []
+    memoization = {}
+
+    recursively_make_operator_order("", operator_set)
+    results = get_possible_calculation(num_set)
+    print(f"#{t_iter} {max(results) - min(results)}")

--- a/happypildo/[SEA]_1W_HW.py
+++ b/happypildo/[SEA]_1W_HW.py
@@ -56,7 +56,6 @@ for t_iter in range(1, T + 1):
         for _ in range(count):
             operator_set = operator_set + OPERATORS[idx]
 
-    # Initialization
     OPERATOR_ORDERS = []
     memoization = {}
 


### PR DESCRIPTION
# 하노이 탑

## 문제 설명
- 잘 알려진 하노이 탑 문제, 판을 옮긴 횟수와 경로를 출력하는 문제이다.

## 알고리즘 분류
- 재귀 함수

## 어려웠던 점
- 수업에 배운 재귀 함수를 공부해보고자 풀어봤는데, 기저 조건은 찾기 쉬웠지만 유도 부분을 고민하는데 시간을 꽤 쓴 것 같음

## 시간 복잡도
- `O(2^n)` (여기서, n은 판 개수)

## 접근 방식
- 봉이 3개 있고 각각을 1, 2, 3번이라 한다.
- 간단하게, 두 개의 판을 1번에서 3번으로  옮긴다고 하면 문제를 다음과 같이 쪼갤 수 있음
    - "한 개(맨 위)의 판을 1번에서 2번으로 옮기고" + "나머지 판(맨 아래)을 1번에서 3번으로 옮기고" + "한 개(맨 위)의 판을 2번에서 3번으로 옮기기"
- 이 방식을 일반화해서 풀었음

## 새로 알게 된 점
- 재귀는 그림 그리면서 풀면 직관을 얻을 수 있는 것 같다.


# 1일차 과제 1번  

## 문제 설명
- 위치가 고정된 숫자 N개가 주어지고, 연산자 N-1개가 주어질 때 가능한 연산 중 가장 작은 값과 큰 값의 차를 구하시오.

## 알고리즘 분류
- 완전 탐색

## 어려웠던 점
- 완전 탐색에서 주의해야 할 시간 복잡도를 해결하는 것이 어려웠음

## 시간 복잡도
- memoization을 활용했기에 어떻게 계산해야할지 모르겠읍니다.

## 접근 방식
- 연산자의 가능한 조합 수를 permutation 형태로 찾고,
- 각 계산 결과를 모아서 최대와 최소를 구함
    - 연산자가 만약 [+, +, +, +, -]가 주어지게 되면 permuation을 단순하게 구하면 시간 초과가 발생 (combination은 순서가 없어서 안 됨)
    - 따라서 memoization 기법을 통해 중복된 연산은 구하지 않게 함

## 새로 알게 된 점
- Memoization을 dictionary로 구현하면 편하다.
