### PR TITLE
유태영 / 9월 1주차 / 3문제

### DIFF
--- a/ramge132/BOJ/BOJ_S1_단지번호붙이기.py
+++ b/ramge132/BOJ/BOJ_S1_단지번호붙이기.py
@@ -1,0 +1,44 @@
+# https://www.acmicpc.net/problem/2667
+
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+# DFS로 연결된 집들을 탐색하는 함수
+def dfs(x, y, N, grid, visited):
+    stack = [(x, y)]
+    visited[x][y] = True
+    house_count = 1
+    
+    while stack:
+        cx, cy = stack.pop()
+        # 상하좌우 방향으로 탐색
+        for i in range(4):
+            nx, ny = cx + dx[i], cy + dy[i]
+            if 0 <= nx < N and 0 <= ny < N and not visited[nx][ny] and grid[nx][ny] == 1:
+                visited[nx][ny] = True
+                stack.append((nx, ny))
+                house_count += 1
+    return house_count
+
+def find_complexes(N, grid):
+    visited = [[False] * N for _ in range(N)]
+    complexes = []
+
+    # 모든 좌표를 순회하며 DFS 탐색을 수행
+    for i in range(N):
+        for j in range(N):
+            if grid[i][j] == 1 and not visited[i][j]:
+                # 새로운 단지를 발견하면 DFS를 통해 단지 크기를 계산
+                complex_size = dfs(i, j, N, grid, visited)
+                complexes.append(complex_size)
+
+    return sorted(complexes)
+
+N = int(input())
+grid = [list(map(int, input().strip())) for _ in range(N)]
+
+complexes = find_complexes(N, grid)
+
+print(len(complexes))
+for size in complexes:
+    print(size)

--- a/ramge132/BOJ/BOJ_S2_연결요소의개수.py
+++ b/ramge132/BOJ/BOJ_S2_연결요소의개수.py
@@ -1,0 +1,32 @@
+# https://www.acmicpc.net/problem/11724
+
+import sys
+sys.setrecursionlimit(10000)
+
+# DFS를 이용한 연결 요소 탐색 함수
+def dfs(node, graph, visited):
+    visited[node] = True
+    # 현재 정점과 연결된 모든 정점을 탐색
+    for neighbor in graph[node]:
+        if not visited[neighbor]:
+            dfs(neighbor, graph, visited)
+
+N, M = map(int, input().split())  # N: 정점의 개수, M: 간선의 개수
+graph = [[] for _ in range(N + 1)]  # 1번 정점부터 N번 정점까지 사용하므로 N+1 크기로 생성
+visited = [False] * (N + 1)  # 방문 여부를 기록하는 리스트
+
+for _ in range(M):
+    u, v = map(int, input().split())
+    graph[u].append(v)
+    graph[v].append(u)
+
+# 연결 요소 개수 카운팅
+connected_components = 0
+
+# 모든 정점을 순회하며 방문하지 않은 정점에서 DFS 실행
+for i in range(1, N + 1):
+    if not visited[i]:
+        dfs(i, graph, visited)
+        connected_components += 1
+
+print(connected_components)

--- a/ramge132/BOJ/BOJ_S2_유기농배추.py
+++ b/ramge132/BOJ/BOJ_S2_유기농배추.py
@@ -1,0 +1,59 @@
+# https://www.acmicpc.net/problem/1012
+
+import sys
+sys.setrecursionlimit(10000)
+
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+# DFS 함수 정의
+def dfs(x, y, M, N, field, visited):
+    stack = [(x, y)]
+    visited[x][y] = True
+    
+    while stack:
+        cx, cy = stack.pop()
+        for i in range(4):
+            nx, ny = cx + dx[i], cy + dy[i]
+            if 0 <= nx < M and 0 <= ny < N and not visited[nx][ny] and field[nx][ny] == 1:
+                visited[nx][ny] = True
+                stack.append((nx, ny))
+
+def solve(T, test_cases):
+    results = []
+    
+    for case in test_cases:
+        M, N, K, positions = case
+        # 배추밭과 방문 여부 초기화
+        field = [[0] * N for _ in range(M)]
+        visited = [[False] * N for _ in range(M)]
+        
+        # 배추 위치 입력
+        for x, y in positions:
+            field[x][y] = 1
+        
+        worm_count = 0
+        
+        # 배추밭을 순회하며 DFS 탐색
+        for i in range(M):
+            for j in range(N):
+                if field[i][j] == 1 and not visited[i][j]:
+                    dfs(i, j, M, N, field, visited)
+                    worm_count += 1
+
+        results.append(worm_count)
+    
+    return results
+
+T = int(input())  
+test_cases = []
+
+for _ in range(T):
+    M, N, K = map(int, input().split()) 
+    positions = [tuple(map(int, input().split())) for _ in range(K)]
+    test_cases.append((M, N, K, positions))
+
+results = solve(T, test_cases)
+
+for result in results:
+    print(result)


### PR DESCRIPTION
DFS 위주로 공부함.
[유기농배추](https://www.acmicpc.net/problem/1012)와 [연결요소의개수](https://www.acmicpc.net/problem/11724)에서
```python
import sys
sys.setrecursionlimit(10000)
```
위와 같이 스터디에서 얘기나왔었던 `sys.setrecursionlimit()`을 사용하였는데,
리마인드 차원으로 파이썬에서는 기본 재귀 깊이 제한이 1,000이다.
이 제한을 10,000으로 풀어준 것

[유기농 배추 문제](https://www.acmicpc.net/problem/1012)를 예시로 
배추밭의 크기가 최대 50×50으로, 
최악의 경우 한 단지가 최대 2,500개의 배추를 포함할 수 있어, 
그만큼의 깊이 재귀 호출이 발생할 수 있음. 

따라서 충분한 재귀 호출을 허용하기 위해 이 설정을 적용.